### PR TITLE
Issue/20,25,27,34

### DIFF
--- a/lib/rester/client.rb
+++ b/lib/rester/client.rb
@@ -20,7 +20,7 @@ module Rester
     end
 
     def connected?
-      adapter.connected? && adapter.get(_path_with_version('status')).first == 200
+      adapter.connected? && adapter.get('/ping').first == 200
     end
 
     def request(verb, path, params={}, &block)

--- a/lib/rester/client/resource.rb
+++ b/lib/rester/client/resource.rb
@@ -25,16 +25,11 @@ module Rester
 
       def method_missing(meth, *args, &block)
         meth = meth.to_s
-
-        unless args.length == 1
-          raise ArgumentError, "wrong number of arguments (#{args.length} for 1)"
-        end
-
         arg = args.first
 
         case arg
-        when Hash
-          _handle_search_or_create(meth, arg)
+        when Hash, NilClass
+          _handle_search_or_create(meth, arg || {})
         when String, Symbol
           Resource.new(client, _path(meth, arg))
         else

--- a/lib/rester/middleware.rb
+++ b/lib/rester/middleware.rb
@@ -2,6 +2,6 @@ module Rester
   module Middleware
     autoload(:Base,          'rester/middleware/base')
     autoload(:ErrorHandling, 'rester/middleware/error_handling')
-    autoload(:StatusCheck,   'rester/middleware/status_check')
+    autoload(:Ping,          'rester/middleware/ping')
   end
 end

--- a/lib/rester/middleware/ping.rb
+++ b/lib/rester/middleware/ping.rb
@@ -2,14 +2,14 @@ module Rester
   module Middleware
     ##
     # Provides a basic status check. Used by the Client#connected? method.
-    class StatusCheck < Base
+    class Ping < Base
       def call(env)
-        if %r{\A/v[\d+]/status\z}.match(env['REQUEST_PATH'])
+        if %r{\A/ping\z}.match(env['REQUEST_PATH'])
           [200, {}, []]
         else
           super
         end
       end
-    end # StatusCheck
+    end # Ping
   end # Middleware
 end # Rester

--- a/lib/rester/service.rb
+++ b/lib/rester/service.rb
@@ -181,8 +181,6 @@ module Rester
     # Prepares the retval from a Service::Resource method to be returned to the
     # client (i.e., validates it and dumps it as JSON).
     def _prepare_response(retval)
-      retval ||= {}
-
       unless retval.is_a?(Hash)
         _error!(Errors::ServerError, "Invalid response: #{retval.inspect}")
       end

--- a/lib/rester/service.rb
+++ b/lib/rester/service.rb
@@ -13,7 +13,7 @@ module Rester
     BASE_MIDDLEWARE = [
       Rack::Head,
       Middleware::ErrorHandling,
-      Middleware::StatusCheck
+      Middleware::Ping
     ].freeze
 
     ########################################################################

--- a/lib/rester/service/resource.rb
+++ b/lib/rester/service/resource.rb
@@ -88,6 +88,10 @@ module Rester
         self.class.validator
       end
 
+      def error!(message=nil)
+        Errors.throw_error!(Errors::RequestError, message)
+      end
+
       private
 
       ##

--- a/lib/rester/service/resource.rb
+++ b/lib/rester/service/resource.rb
@@ -77,7 +77,7 @@ module Rester
         meth = (id_provided ? REQUEST_METHOD_TO_IDENTIFIED_METHOD
           : REQUEST_METHOD_TO_UNIDENTIFIED_METHOD)[request_method]
 
-        _process(meth, params)
+        _process(meth, params).to_h
       end
 
       def mounts

--- a/spec/dummy/dummy_service.rb
+++ b/spec/dummy/dummy_service.rb
@@ -44,6 +44,9 @@ module Rester
         end
 
         def get(params)
+          error! if params[:string] == 'testing_error'
+          error!(params[:string]) if params[:string] == 'testing_error_with_message'
+
           { token: params.delete(:test_token), params: params, method: :get }
         end
 

--- a/spec/dummy/dummy_service.rb
+++ b/spec/dummy/dummy_service.rb
@@ -83,6 +83,16 @@ module Rester
           { token: params.delete(:test_token), params: params, method: :get }
         end
       end # TestWithDefaults
+
+      class TestWithNonHashValue < Service::Resource
+        params do
+          Boolean :nil_return_val, default: false
+        end
+
+        def search(params)
+          params[:nil_return_val] ? nil : [[:this, :that]]
+        end
+      end # TestWithNonHashValue
     end # V1
   end # DummyService
 end # Rester

--- a/spec/rester/client_spec.rb
+++ b/spec/rester/client_spec.rb
@@ -110,6 +110,20 @@ module Rester
                   it { is_expected.to eq(expected_resp) }
                 end
 
+                context 'with triggered error!' do
+                  let(:params) { {string: 'testing_error'} }
+                  it 'should raise an error' do
+                    expect { subject }.to raise_error Rester::Errors::RequestError, 'Rester::Errors::RequestError'
+                  end
+
+                  context 'with message' do
+                    let(:params) { {string: 'testing_error_with_message'} }
+                    it 'should raise an error' do
+                      expect { subject }.to raise_error Rester::Errors::RequestError, 'testing_error_with_message'
+                    end
+                  end
+                end
+
                 context 'with nil argument' do
                   let(:params) { nil }
                   it { is_expected.to eq(token: 'token', params: {}, method: 'get') }

--- a/spec/rester/client_spec.rb
+++ b/spec/rester/client_spec.rb
@@ -211,7 +211,7 @@ module Rester
 
           context 'with no arguments' do
             let(:args) { [] }
-            it { expect { subject }.to raise_error ArgumentError, 'wrong number of arguments (0 for 1)' }
+            it { is_expected.to eq(method: 'search') }
           end # with no arguments
         end # with supported version
       end # with connection
@@ -224,7 +224,7 @@ module Rester
       context 'without connection' do
         context 'with no arguments' do
           let(:args) { [] }
-          it { expect { subject }.to raise_error ArgumentError, 'wrong number of arguments (0 for 1)' }
+          it { expect { subject }.to raise_error RuntimeError, 'not connected' }
         end
 
         context 'with hash argument' do
@@ -238,7 +238,7 @@ module Rester
 
         context 'with no arguments' do
           let(:args) { [] }
-          it { expect { subject }.to raise_error ArgumentError, 'wrong number of arguments (0 for 1)' }
+          it { is_expected.to eq(method: 'create') }
         end
 
         context 'with hash argument' do

--- a/spec/rester/service/resource_spec.rb
+++ b/spec/rester/service/resource_spec.rb
@@ -22,6 +22,19 @@ module Rester
           expect(object.validator.strict?).to be true
         end
       end # ::params
+
+      describe '#process' do
+        let(:resource) { Rester::DummyService::V1::TestWithNonHashValue.new }
+        let(:params) { {} }
+        subject { resource.process('GET', nil, params) }
+
+        it { is_expected.to eq(this: :that) }
+
+        context 'with nil retval' do
+          let(:params) { { "nil_return_val" => "true" } }
+          it { is_expected.to eq({}) }
+        end
+      end # #process
     end # Resource
   end # Service
 end # Rester

--- a/spec/rester/service/resource_spec.rb
+++ b/spec/rester/service/resource_spec.rb
@@ -35,6 +35,28 @@ module Rester
           it { is_expected.to eq({}) }
         end
       end # #process
+
+      describe '#error!' do
+        let(:message) { nil }
+        let(:resource) { Rester::DummyService::V1::Test.new }
+        subject {
+          catch(:error) do
+            resource.error!(message)
+          end
+        }
+
+        it 'should raise an error' do
+          expect(subject).to be_a Rester::Errors::RequestError
+        end
+
+        context 'with message' do
+          let(:message) { "Error Message" }
+
+          it 'should raise an error' do
+            expect(subject).to eq Rester::Errors::RequestError.new(message)
+          end
+        end # with message
+      end # #error!
     end # Resource
   end # Service
 end # Rester


### PR DESCRIPTION
[#20] - Allow no arguments to be passed to Client::Resource#method_missing
[#25] - Call to_h on returned Service values
[#27] - Change StatusCheck middleware to Ping
[#34] - Create helper method `error!` to respond with a RequestError (400) 