### PR TITLE
No longer symbolizing stub request keys

### DIFF
--- a/lib/rester/client/adapters/stub_adapter.rb
+++ b/lib/rester/client/adapters/stub_adapter.rb
@@ -66,8 +66,7 @@ module Rester
         end
 
         # Verify body, if there is one
-        request = action['request'] || {}
-        unless Utils.symbolize_keys(request) == params
+        unless (request = action['request'] || {}) == params
           fail Errors::StubError,
             "#{verb} #{path} with context '#{context}' params don't match stub. Expected: #{request} Got: #{params}"
         end
@@ -82,8 +81,8 @@ module Rester
       # Find the first request object with the same params as what's passed in.
       # Useful for testing without having to set the context.
       def _find_context_by_params(path, verb, params)
-        (stub[path][verb].find { |context, action|
-          Utils.symbolize_keys(action['request'] || {}) == params
+        (stub[path][verb].find { |_, action|
+          (action['request'] || {}) == params
         } || []).first
       end
     end # StubAdapter

--- a/spec/rester/client/adapters/stub_adapter_spec.rb
+++ b/spec/rester/client/adapters/stub_adapter_spec.rb
@@ -84,9 +84,9 @@ module Rester
           context 'with matching params' do
             let(:params) {
               {
-                card_number: "4111111111111111",
-                exp_month: "08",
-                exp_year: "2017"
+                'card_number' => "4111111111111111",
+                'exp_month' => "08",
+                'exp_year' => "2017"
               }
             }
 
@@ -149,12 +149,12 @@ module Rester
             end # with non-existent card
 
             context 'with invalid params' do
-              let(:params) {{ bad_field: 'bad_field' }}
+              let(:params) {{ 'bad_field' => 'bad_field' }}
               let(:context) { 'With card existing' }
 
               it 'should raise an error' do
                 expect { subject }.to raise_error Errors::StubError,
-                  "GET /v1/cards/CTabcdef with context 'With card existing' params don't match stub. Expected: {} Got: {:bad_field=>\"bad_field\"}"
+                  "GET /v1/cards/CTabcdef with context 'With card existing' params don't match stub. Expected: {} Got: {\"bad_field\"=>\"bad_field\"}"
               end
             end # with invalid params
           end # with path /v1/cards/CTabcdef
@@ -189,9 +189,9 @@ module Rester
             context 'with valid card details' do
               let(:context) { 'With valid card details' }
               let(:params) { {
-                card_number: "4111111111111111",
-                exp_month: "08",
-                exp_year: "2017"
+                'card_number' => "4111111111111111",
+                'exp_month' => "08",
+                'exp_year' => "2017"
               }}
 
               it 'should return 200 status' do
@@ -206,9 +206,9 @@ module Rester
             context 'with expired card' do
               let(:context) { 'With expired card' }
               let(:params) { {
-                card_number: "411111111",
-                exp_month: "01",
-                exp_year: "2000"
+                'card_number' => "411111111",
+                'exp_month' => "01",
+                'exp_year' => "2000"
               }}
 
               it 'should return 400 status' do
@@ -231,9 +231,9 @@ module Rester
             context 'with valid customer' do
               let(:context) { 'Valid customer' }
               let(:params) { {
-                name: "John Smith",
-                city: "San Francisco",
-                state: "CA"
+                'name' => "John Smith",
+                'city' => "San Francisco",
+                'state' => "CA"
               }}
 
               it 'should return 200 status' do


### PR DESCRIPTION
#45

The Adapter class ensures that all keys and values are passed to the StubAdapter as strings.  Symbolizing the stub request keys causes prevents the StubAdapter from recognizing a match.