### PR TITLE
[#53] Making params strict by default.

### DIFF
--- a/lib/rester/service/resource.rb
+++ b/lib/rester/service/resource.rb
@@ -64,7 +64,8 @@ module Rester
 
         def method_added(method_name)
           if RESOURCE_METHODS.include?(method_name.to_sym)
-            method_params[method_name.to_sym] = (@_next_params || Params.new).freeze
+            method_params[method_name.to_sym] = (@_next_params ||
+              Params.new(strict: false)).freeze
           end
           @_next_params = nil
         end

--- a/lib/rester/service/resource/params.rb
+++ b/lib/rester/service/resource/params.rb
@@ -21,7 +21,7 @@ module Rester
       # Whether or not validation will be done strictly (i.e., only specified
       # params will be allowed).
       def strict?
-        !!options[:strict]
+        !!options.fetch(:strict, true)
       end
 
       def freeze

--- a/lib/rester/service/resource/params.rb
+++ b/lib/rester/service/resource/params.rb
@@ -1,12 +1,13 @@
 module Rester
   class Service::Resource
     class Params
+      DEFAULT_OPTS = { strict: true }.freeze
       BASIC_TYPES = [String, Symbol, Float, Integer].freeze
 
       attr_reader :options
 
       def initialize(opts={}, &block)
-        @options = opts.dup.freeze
+        @options = DEFAULT_OPTS.merge(opts).freeze
         @_required_fields = []
         @_defaults = {}
         @_all_fields = []
@@ -21,7 +22,7 @@ module Rester
       # Whether or not validation will be done strictly (i.e., only specified
       # params will be allowed).
       def strict?
-        !!options.fetch(:strict, true)
+        !!options[:strict]
       end
 
       def freeze

--- a/spec/dummy/dummy_service.rb
+++ b/spec/dummy/dummy_service.rb
@@ -33,6 +33,9 @@ module Rester
           Float   :float
           Symbol  :symbol
           Boolean :bool
+          String  :test_token
+          String  :null
+          String  :test
         }
 
         params do


### PR DESCRIPTION
#53

The exception here is if no Params are defined for a method.  Then an
empty params set that’s not strict is created.