### PR TITLE
Adding support for array and hash params

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,12 @@ class ExampleService < Rester::Service
         Array :array, type: Float, within: (0..1)
 
         # Arrays of hashes work, too.
-        Array :array_of_hashes, type: Hash, strict: false do
+        #
+        # CAUTION: Each hash in the array must contain the same keys in order to
+        # ensure they are properly decoded on the service-side. To be on the
+        # safe side, make nested hashes like this strict and all their params
+        # required.  To be on the safer side, don't use this :)
+        Array :array_of_hashes, type: Hash, strict: true do
           # Another params block!
         end
       end

--- a/README.md
+++ b/README.md
@@ -142,6 +142,61 @@ MyService = Rester.connect('http://example.com', version: 1, error_threshold: 5,
 
 In this example, the circuit will open if 5 consecutive errors occur (e.g., timeout errors or errors raised on the server). Once the circuit is open, any request made to the client will raise a `Rester::Errors::CircuitOpenError` without actually making the request. This reduces the load on recovering downstream systems and helps prevent timeouts from propagating (i.e., timeouts in one service causing timeouts in another service). Once the `retry_period` of 2 seconds has passed, the next request will be allowed through. If it succeeds, the circuit will close again and all requests will be permitted through again. If it fails, the circuit will remain open.
 
+## Service Params
+```ruby
+class ExampleService < Rester::Service
+  module V1
+    class MyResource < Rester::Service::Resource
+      # By default all params blocks are strict.
+      params strict: true do
+        # Any method that can be called on the object can be used to validate
+        # it. Here the `#between?` method will be called with the args (1, 10).
+        # As long as the method returns truthy, the validation will pass.
+        Integer :integer, between?: [1,10]
+
+        # Here's another example (not sure how this would be useful though!)
+        Float :float, zero?: []
+
+        # Boolean has special handling since Ruby doesn't have a Boolean object.
+        Boolean :bool
+
+        # Any other data type can be used, too! But it needs to provide a
+        # ::parse class method, like DateTime.
+        DateTime :date
+
+        # Use the `match` validator to validate the value sent to the server
+        # *before* it is parsed (note: this is a bad date regex!).
+        DateTime :date, match: /\A\d{4}-\d{2}-\d{2}\z/
+
+        # Use the `within` matcher to verify that the object is within an
+        # expected set.
+        Symbol :symbol, within: [:one, :two, :three]
+
+        # `within` will also work with anything that responds to `include?`,
+        # a range for example.
+        Float :another_float, within: (0..1)
+
+        # Nested hashes are also supported.
+        Hash :hash, strict: false do
+          # Another params block!
+        end
+
+        # Arrays are supported, too. Here validators apply to each element of
+        # the array individually.
+        Array :array, type: Float, within: (0..1)
+
+        # Arrays of hashes work, too.
+        Array :array_of_hashes, type: Hash, strict: false do
+          # Another params block!
+        end
+      end
+      def get
+      end
+    end
+  end
+end
+```
+
 ## Contract Testing
 
 ### Client-side Stub Testing

--- a/lib/rester/client/adapters/adapter.rb
+++ b/lib/rester/client/adapters/adapter.rb
@@ -79,7 +79,7 @@ module Rester
 
       def _validate_verb(verb)
         VALID_VERBS[verb] or
-          raise ArgumentError, "Invalid verb: #{verb.inspect}"
+          fail ArgumentError, "Invalid verb: #{verb.inspect}"
       end
     end # Adapter
   end # Client::Adapters

--- a/lib/rester/client/adapters/http_adapter.rb
+++ b/lib/rester/client/adapters/http_adapter.rb
@@ -25,24 +25,14 @@ module Rester
         !!connection
       end
 
-      def get!(path, params={})
+      def request!(verb, path, encoded_data)
         _require_connection
-        _prepare_response(connection.get(path, headers: headers, query: params))
-      end
 
-      def delete!(path, params={})
-        _require_connection
-        _prepare_response(connection.delete(path, headers: headers, query: params))
-      end
+        data_key = [:get, :delete].include?(verb) ? :query : :data
+        response = connection.request(verb, path,
+          headers: headers, data_key => encoded_data)
 
-      def put!(path, params={})
-        _require_connection
-        _prepare_response(connection.put(path, headers: headers, data: params))
-      end
-
-      def post!(path, params={})
-        _require_connection
-        _prepare_response(connection.post(path, headers: headers, data: params))
+        _prepare_response(response)
       end
 
       private

--- a/lib/rester/client/adapters/http_adapter/connection.rb
+++ b/lib/rester/client/adapters/http_adapter/connection.rb
@@ -18,37 +18,12 @@ module Rester
         @timeout = opts[:timeout]
       end
 
-      def get(path, params={})
+      def request(verb, path, params={})
         _request(
-          :get,
+          verb,
           _path(path, params[:query]),
-          _prepare_headers(params[:headers])
-        )
-      end
-
-      def delete(path, params={})
-        _request(
-          :delete,
-          _path(path, params[:query]),
-          _prepare_headers(params[:headers])
-        )
-      end
-
-      def put(path, params={})
-        _request(
-          :put,
-          _path(path),
-          _prepare_data_headers(params[:headers]),
-          _encode_data(params[:data])
-        )
-      end
-
-      def post(path, params={})
-        _request(
-          :post,
-          _path(path),
-          _prepare_data_headers(params[:headers]),
-          _encode_data(params[:data])
+          _headers(verb, params[:headers]),
+          params[:data]
         )
       end
 
@@ -64,12 +39,16 @@ module Rester
       def _path(path, query=nil)
         u = url.dup
         u.path = Utils.join_paths(u.path, path)
-        u.query = _encode_data(query) if query && !query.empty?
+        u.query = query if query
         u.request_uri
       end
 
-      def _encode_data(data)
-        Utils.encode_www_data(data)
+      def _headers(verb, headers)
+        if [:post, :put].include?(verb)
+          _prepare_data_headers(headers)
+        else
+          _prepare_headers(headers)
+        end
       end
 
       def _prepare_data_headers(headers)

--- a/lib/rester/client/adapters/http_adapter/connection.rb
+++ b/lib/rester/client/adapters/http_adapter/connection.rb
@@ -29,8 +29,7 @@ module Rester
 
       private
 
-      def _request(verb, path, headers={}, data='')
-        data = nil if [:get, :delete].include?(verb)
+      def _request(verb, path, headers, data)
         _http.public_send(verb, *[path, data, headers].compact)
       rescue Net::ReadTimeout, Net::OpenTimeout
         fail Errors::TimeoutError

--- a/lib/rester/client/adapters/http_adapter/connection.rb
+++ b/lib/rester/client/adapters/http_adapter/connection.rb
@@ -64,12 +64,12 @@ module Rester
       def _path(path, query=nil)
         u = url.dup
         u.path = Utils.join_paths(u.path, path)
-        u.query = URI.encode_www_form(query) if query && !query.empty?
+        u.query = _encode_data(query) if query && !query.empty?
         u.request_uri
       end
 
       def _encode_data(data)
-        URI.encode_www_form(data || {})
+        Utils.encode_www_data(data)
       end
 
       def _prepare_data_headers(headers)

--- a/lib/rester/client/adapters/local_adapter.rb
+++ b/lib/rester/client/adapters/local_adapter.rb
@@ -12,7 +12,7 @@ module Rester
 
       class << self
         def can_connect_to?(service)
-          service.is_a?(Class) && service < Service
+          service.is_a?(Class) && !!(service < Service)
         end
       end # Class Methods
 
@@ -24,31 +24,16 @@ module Rester
         !!service
       end
 
-      def get!(path, params={})
-        _request(:get, path, headers: headers, query: params)
-      end
-
-      def delete!(path, params={})
-        _request(:delete, path, headers: headers, query: params)
-      end
-
-      def put!(path, params={})
-        _request(:put, path, headers: headers, data: params)
-      end
-
-      def post!(path, params={})
-        _request(:post, path, headers: headers, data: params)
+      def request!(verb, path, encoded_data)
+        data_key = [:get, :delete].include?(verb) ? :query : :data
+        _request(verb, path, headers: headers, data_key => encoded_data)
       end
 
       private
 
-      def _encode_data(data)
-        Utils.encode_www_data(data) || ''
-      end
-
       def _request(verb, path, opts={})
-        body = _encode_data(opts[:data])
-        query = _encode_data(opts[:query])
+        body = opts[:data] || ''
+        query = opts[:query] || ''
 
         response = Timeout::timeout(timeout) do
           service.call(

--- a/lib/rester/client/adapters/local_adapter.rb
+++ b/lib/rester/client/adapters/local_adapter.rb
@@ -42,9 +42,13 @@ module Rester
 
       private
 
+      def _encode_data(data)
+        Utils.encode_www_data(data) || ''
+      end
+
       def _request(verb, path, opts={})
-        body = URI.encode_www_form(opts[:data] || {})
-        query = URI.encode_www_form(opts[:query] || {})
+        body = _encode_data(opts[:data])
+        query = _encode_data(opts[:query])
 
         response = Timeout::timeout(timeout) do
           service.call(

--- a/lib/rester/client/adapters/stub_adapter.rb
+++ b/lib/rester/client/adapters/stub_adapter.rb
@@ -30,20 +30,9 @@ module Rester
         !!stub
       end
 
-      def get!(path, params={})
-        _request('GET', path, params)
-      end
-
-      def post!(path, params={})
-        _request('POST', path, params)
-      end
-
-      def put!(path, params={})
-        _request('PUT', path, params)
-      end
-
-      def delete!(path, params={})
-        _request('DELETE', path, params)
+      def request!(verb, path, encoded_data)
+        params = Rack::Utils.parse_nested_query(encoded_data)
+        _request(verb.to_s.upcase, path, params)
       end
 
       def with_context(context)
@@ -73,7 +62,8 @@ module Rester
         # Verify body, if there is one
         unless (request = spec['request']) == params
           fail Errors::StubError,
-            "#{verb} #{path} with context '#{context}' params don't match stub. Expected: #{request} Got: #{params}"
+            "#{verb} #{path} with context '#{context}' params don't match "\
+            "stub. Expected: #{request} Got: #{params}"
         end
 
         # At this point, the 'request' is valid by matching a corresponding

--- a/lib/rester/service/resource/params.rb
+++ b/lib/rester/service/resource/params.rb
@@ -2,7 +2,7 @@ module Rester
   class Service::Resource
     class Params
       DEFAULT_OPTS = { strict: true }.freeze
-      BASIC_TYPES = [String, Symbol, Float, Integer].freeze
+      BASIC_TYPES = [String, Symbol, Float, Integer, Array, Hash].freeze
 
       DEFAULT_TYPE_MATCHERS = {
         Integer  => /\A\d+\z/,
@@ -59,14 +59,8 @@ module Rester
       end
 
       def validate!(key, value)
-        _error!("expected string value for #{key}") unless value.is_a?(String)
-
         klass, opts = @_validators[key]
-        _validate_match(key, value, opts[:match]) if opts[:match]
-
-        _parse_with_class(klass, value).tap do |obj|
-          _validate_obj(key, obj)
-        end
+        _validate(key, value, klass, opts)
       end
 
       def use(params)
@@ -83,7 +77,13 @@ module Rester
       # them so we can capture their calls. If this weren't the case, then we'd
       # be catch them in `method_missing`.
       BASIC_TYPES.each do |type|
-        define_method(type.to_s) { |name, opts={}|
+        define_method(type.to_s) { |name, opts={}, &block|
+          if type == Hash || (type == Array && opts[:type] == Hash)
+            elem_type = (options = @options.merge(opts)).delete(:type)
+            opts = elem_type ? { type: elem_type } : {}
+            opts.merge!(use: self.class.new(options, &block))
+          end
+
           _add_validator(name, type, opts)
         }
       end
@@ -167,6 +167,45 @@ module Rester
         raise error if error
       end
 
+      ##
+      # Validates and parses a given value. `klass` is the intended type for the
+      # value (e.g., String, Integer, Array, etc.). `opts` contains the
+      # validation options.
+      def _validate(key, value, klass, opts)
+        case value
+        when String
+          _validate_str(key, value, klass, opts)
+        when Array
+          _validate_array(key, value, klass, opts)
+        when Hash
+          _validate_hash(key, value, klass, opts)
+        else
+          _error!("unexpected value type for #{key}: #{value.class}")
+        end
+      end
+
+      def _validate_str(key, value, klass, opts)
+        fail unless value.is_a?(String) # assert
+
+        _validate_match(key, value, opts[:match]) if opts[:match]
+        _parse_with_class(klass, value).tap do |obj|
+          _validate_required(key, obj)
+          _validate_type(key, obj, klass) if obj
+          _validate_obj(key, obj, opts)
+        end
+      end
+
+      def _validate_array(key, value, klass, opts)
+        _error!("unexpected array for #{key}") unless klass == Array
+        type = (opts = opts.dup).delete(:type) || String
+        value.map { |elem| _validate(key, elem, type, opts) }
+      end
+
+      def _validate_hash(key, value, klass, opts)
+        _error!("unexpected hash for #{key}") unless klass == Hash
+        (validator = opts[:use]) && validator.validate(value)
+      end
+
       def _parse_with_class(klass, value)
         return nil if value == 'null'
 
@@ -185,13 +224,10 @@ module Rester
         end
       end
 
-      def _validate_obj(key, obj)
+      def _validate_obj(key, obj, opts)
         if obj.nil? && @_required_fields.include?(key)
           _error!("#{key} cannot be null")
         end
-
-        klass, opts = @_validators[key]
-        _validate_type(key, obj, klass) if obj
 
         opts.each do |opt, value|
           case opt
@@ -210,6 +246,16 @@ module Rester
           # The .camelcase here is for when type = 'boolean'
           _error!("#{key} should be #{type.to_s.camelcase} but "\
             "got #{obj.class}")
+        end
+      end
+
+      def _validate_required(key, obj)
+        if obj.nil? && @_required_fields.include?(key)
+          if @_validators[key].first == Array
+            _error!("#{key} cannot contain null elements")
+          else
+            _error!("#{key} cannot be null")
+          end
         end
       end
 

--- a/lib/rester/service/resource/params.rb
+++ b/lib/rester/service/resource/params.rb
@@ -184,7 +184,7 @@ module Rester
         when Hash
           _validate_hash(key, value, klass, opts)
         when NilClass
-          _validate_required(key, !!value)
+          _validate_required(key, false)
         else
           _error!("unexpected value type for #{key}: #{value.class}")
         end

--- a/lib/rester/utils.rb
+++ b/lib/rester/utils.rb
@@ -45,6 +45,10 @@ module Rester
         end
       end
 
+      def decode_www_data(data)
+        Rack::Utils.parse_nested_query(data)
+      end
+
       def escape(value)
         URI.encode_www_form_component(value)
       end
@@ -79,17 +83,10 @@ module Rester
         hash.inject({}){|memo,(k,v)| memo[k.to_sym] = v; memo}
       end
 
-      def stringify_vals(hash={})
-        hash.each_with_object({}) { |(k,v), memo|
-          case v
-          when Hash
-            memo[k] = stringify_vals(v)
-          when NilClass
-            memo[k] = 'null'
-          else
-            memo[k] = v.to_s
-          end
-        }
+      ##
+      # Converts all keys and values to strings.
+      def stringify(hash={})
+        decode_www_data(encode_www_data(hash))
       end
 
       def classify(str)

--- a/lib/rester/utils.rb
+++ b/lib/rester/utils.rb
@@ -1,4 +1,5 @@
 require 'date'
+require 'uri'
 
 module Rester
   module Utils
@@ -18,6 +19,34 @@ module Rester
         else
           [:get, meth]
         end
+      end
+
+      ##
+      # Copied from Rack::Utils.build_nested_query (version 1.6.0)
+      #
+      # We want to be able to support Rack >= 1.5.2, but this method is broken
+      # in that version.
+      def encode_www_data(value, prefix = nil)
+        # Rack::Utils.build_nested_query(value)
+        case value
+        when Array
+          value.map { |v|
+            encode_www_data(v, "#{prefix}[]")
+          }.join("&")
+        when Hash
+          value.map { |k, v|
+            encode_www_data(v, prefix ? "#{prefix}[#{escape(k)}]" : escape(k))
+          }.reject(&:empty?).join('&')
+        when nil
+          prefix
+        else
+          raise ArgumentError, "value must be a Hash" if prefix.nil?
+          "#{prefix}=#{escape(value)}"
+        end
+      end
+
+      def escape(value)
+        URI.encode_www_form_component(value)
       end
 
       def join_paths(*paths)

--- a/lib/rester/utils/stub_file.rb
+++ b/lib/rester/utils/stub_file.rb
@@ -56,7 +56,7 @@ module Rester
         # Converts all the values in the request hash to strings, which mimics
         # how the data will be received on the service side.
         def _update_request(path, verb, context, spec)
-          spec['request'] = Utils.stringify_vals(spec['request'] || {})
+          spec['request'] = Utils.stringify(spec['request'] || {})
         end
 
         ##

--- a/spec/rester/client/adapters/adapter_spec.rb
+++ b/spec/rester/client/adapters/adapter_spec.rb
@@ -1,0 +1,237 @@
+module Rester
+  module Client::Adapters
+    RSpec.describe Adapter do
+      # TODO: Test that verbs, paths and params are passed to the subclass
+      # as expected. Particularly, that params are encoded properly beforehand.
+
+      let(:adapter_class) { Class.new(Adapter) }
+      let(:adapter) { adapter_class.new(service, opts) }
+      let(:service) { nil }
+      let(:opts) { {} }
+
+      describe '#timeout' do
+        subject { adapter.timeout }
+
+        context 'without the timeout option specified' do
+          let(:opts) { {} }
+          it { is_expected.to be nil }
+        end
+
+        context 'with the timeout option given as integer' do
+          let(:opts) { { timeout: 1234 } }
+          it { is_expected.to be 1234 }
+        end
+
+        context 'with the timeout option given as float' do
+          let(:opts) { { timeout: 3.14159 } }
+          it { is_expected.to be 3.14159 }
+        end
+      end # #timeout
+
+      describe '#request' do
+        subject { adapter.request(verb, path, params) }
+        let(:verb) { :get }
+        let(:path) { '/' }
+        let(:params) { nil }
+
+        context 'with GET "/" and no params' do
+          it 'should call #request! with correct args' do
+            expect(adapter).to receive(:request!).with(verb, path, nil).once
+            subject
+          end
+        end
+
+        context 'with integer params' do
+          let(:params) { { a: 1, b: 2, c: 3 } }
+
+          it 'should call #request! with correct args' do
+            expect(adapter).to receive(:request!)
+              .with(verb, path, 'a=1&b=2&c=3').once
+            subject
+          end
+        end
+
+        context 'with string params' do
+          let(:params) { { a: 'aaa', b: 'bbb', c: 'ccc' } }
+
+          it 'should call #request! with correct args' do
+            expect(adapter).to receive(:request!)
+              .with(verb, path, 'a=aaa&b=bbb&c=ccc').once
+            subject
+          end
+        end
+
+        context 'with float params' do
+          let(:params) { { a: 1.1, b: 2.22, c: 3.333 } }
+
+          it 'should call #request! with correct args' do
+            expect(adapter).to receive(:request!)
+              .with(verb, path, 'a=1.1&b=2.22&c=3.333').once
+            subject
+          end
+        end
+
+        context 'with symbol params' do
+          let(:params) { { a: :one, b: :two, c: :three } }
+
+          it 'should call #request! with correct args' do
+            expect(adapter).to receive(:request!)
+              .with(verb, path, 'a=one&b=two&c=three').once
+            subject
+          end
+        end
+
+        context 'with nil params' do
+          let(:params) { { a: nil, b: nil, c: nil } }
+
+          it 'should call #request! with correct args' do
+            expect(adapter).to receive(:request!).with(verb, path, 'a&b&c').once
+            subject
+          end
+        end
+
+        context 'with empty array param' do
+          let(:params) { { a: [] } }
+
+          it 'should call #request! with correct args' do
+            expect(adapter).to receive(:request!).with(verb, path, '').once
+            subject
+          end
+        end
+
+        context 'with non-empty array param' do
+          let(:params) { { a: ['one', 2, 3.3] } }
+
+          it 'should call #request! with correct args' do
+            expect(adapter).to receive(:request!)
+              .with(verb, path, 'a[]=one&a[]=2&a[]=3.3').once
+            subject
+          end
+        end
+
+        context 'with non-empty array param containing a nil' do
+          let(:params) { { a: ['one', nil, 3.3] } }
+
+          it 'should call #request! with correct args' do
+            expect(adapter).to receive(:request!)
+              .with(verb, path, 'a[]=one&a[]&a[]=3.3').once
+            subject
+          end
+        end
+
+        context 'with two non-empty array params' do
+          let(:params) { { a: ['one', 2, 3.3], b: [1, 2.2] } }
+
+          it 'should call #request! with correct args' do
+            expect(adapter).to receive(:request!)
+              .with(verb, path, 'a[]=one&a[]=2&a[]=3.3&b[]=1&b[]=2.2').once
+            subject
+          end
+        end
+
+        context 'with nested empty array param' do
+          let(:params) { { a: [[]] } }
+
+          it 'should call #request! with correct args' do
+            expect(adapter).to receive(:request!).with(verb, path, '').once
+            subject
+          end
+        end
+
+        context 'with nested non-empty array param' do
+          let(:params) { { a: [[1], [1,2], [1,2,3]] } }
+
+          it 'should call #request! with correct args' do
+            expect(adapter).to receive(:request!)
+              .with(verb, path, 'a[][]=1&a[][]=1&a[][]=2&a[][]=1&a[][]=2&'\
+                'a[][]=3').once
+            subject
+          end
+        end
+
+        context 'with array with nested hashes param' do
+          let(:params) do
+            { a: [{one: 1}, {one: 1, two: 2}, {one: 1, two: 2, three: 3}] }
+          end
+
+          it 'should call #request! with correct args' do
+            expect(adapter).to receive(:request!)
+              .with(verb, path, 'a[][one]=1&a[][one]=1&a[][two]=2&a[][one]=1&'\
+                'a[][two]=2&a[][three]=3').once
+            subject
+          end
+        end
+
+        context 'with empty hash param' do
+          let(:params) { { a: {} } }
+
+          it 'should call #request! with correct args' do
+            expect(adapter).to receive(:request!).with(verb, path, '').once
+            subject
+          end
+        end
+
+        context 'with non-empty hash param' do
+          let(:params) { { a: { a: 1, b: 2.2, c: 'three', ary: [1,2]} } }
+
+          it 'should call #request! with correct args' do
+            expect(adapter).to receive(:request!)
+              .with(verb, path, 'a[a]=1&a[b]=2.2&a[c]=three&a[ary][]=1&'\
+                'a[ary][]=2').once
+            subject
+          end
+        end
+
+        context 'with nested hash param' do
+          let(:params) { { a: { hash: { one: 1, two: 2 } } } }
+
+          it 'should call #request! with correct args' do
+            expect(adapter).to receive(:request!)
+              .with(verb, path, 'a[hash][one]=1&a[hash][two]=2').once
+            subject
+          end
+        end
+
+        context 'with POST "/tests" and no params' do
+          let(:verb) { :post }
+          let(:path) { '/tests' }
+
+          it 'should call #request! with correct args' do
+            expect(adapter).to receive(:request!).with(verb, path, nil).once
+            subject
+          end
+        end
+
+        context 'with PUT "/some/endpoint/here" and no params' do
+          let(:verb) { :put }
+          let(:path) { '/some/endpoint/here' }
+
+          it 'should call #request! with correct args' do
+            expect(adapter).to receive(:request!).with(verb, path, nil).once
+            subject
+          end
+        end
+
+        context 'with DELETE "some-other-resource" and no params' do
+          let(:verb) { :put }
+          let(:path) { 'some-other-resource' }
+
+          it 'should call #request! with correct args' do
+            expect(adapter).to receive(:request!).with(verb, path, nil).once
+            subject
+          end
+        end
+
+        context 'with OPTIONS "/path" and no params' do
+          let(:verb) { :options }
+          let(:path) { '/path' }
+
+          it 'should call #request! with correct args' do
+            expect { subject }.to raise_error ArgumentError,
+              'Invalid verb: :options'
+          end
+        end
+      end # #request
+    end # Adapter
+  end # Client::Adapters
+end # Rester

--- a/spec/rester/client/adapters/http_adapter_spec.rb
+++ b/spec/rester/client/adapters/http_adapter_spec.rb
@@ -2,8 +2,8 @@ module Rester
   module Client::Adapters
     RSpec.describe HttpAdapter do
       let(:url) { RSpec.server_uri.to_s }
-      let(:opts) { {} }
-      let(:adapter) { HttpAdapter.new(url, opts) }
+      let(:adapter_opts) { {} }
+      let(:adapter) { HttpAdapter.new(url, adapter_opts) }
 
       describe '::can_connect_to?' do
         subject { HttpAdapter.can_connect_to?(service) }
@@ -45,19 +45,21 @@ module Rester
         end # with invalid URI scheme
       end # ::can_connect_to?
 
-      describe '#get!', :get! do
-        let(:params) { {} }
-        subject { adapter.get!(path, params) }
+      describe '#request!', :request! do
+        let(:params) { nil }
+        let(:encoded_data) { Utils.encode_www_data(params) }
+        subject { adapter.request!(verb, path, params) }
 
         context 'with request timeout' do
-          let(:opts) { { timeout: 0.001 } }
+          let(:verb) { :get }
           let(:path) { '/v1/commands/sleep' }
+          let(:adapter_opts) { { timeout: 0.001 } }
 
           it 'should raise timeout error' do
             expect { subject }.to raise_error Errors::TimeoutError
           end
         end # with request timeout
-      end # #get!
+      end # #request!
     end # HttpAdapter
   end # Client::Adapters
 end # Rester

--- a/spec/rester/client/adapters/local_adapter_spec.rb
+++ b/spec/rester/client/adapters/local_adapter_spec.rb
@@ -66,6 +66,27 @@ module Rester
           let(:path) { '/v1/tests/test_id' }
           it { is_expected.to eq [200, '{"test_id":"test_id"}'] }
         end
+
+        context 'PUT /v1/tests/test_id' do
+          let(:verb) { :put }
+          let(:path) { '/v1/tests/test_id' }
+
+          context 'without array param' do
+            it { is_expected.to eq [200, '{"test_id":"test_id"}'] }
+          end
+
+          context 'with array param' do
+            let(:params) { { a: ['one', 2, 3.3] } }
+            it { is_expected.to eq [200, '{"a":["one","2","3.3"],'\
+              '"test_id":"test_id"}'] }
+          end
+
+          context 'with hash param' do
+            let(:params) { { h: { key: 'value' } } }
+            it { is_expected.to eq [200, '{"h":{"key":"value"},'\
+              '"test_id":"test_id"}'] }
+          end
+        end
       end # #request!
     end # LocalAdapter
   end # Client::Adapters

--- a/spec/rester/client/adapters/stub_adapter_spec.rb
+++ b/spec/rester/client/adapters/stub_adapter_spec.rb
@@ -1,7 +1,7 @@
 module Rester
   module Client::Adapters
     RSpec.describe StubAdapter do
-      let(:stub_file_path) { 'spec/stubs/dummy_stub.yml' }
+      let(:stub_file_path) { 'spec/stubs/stub_adapter_test_stub.yml' }
       let(:stub_adapter) { StubAdapter.new(stub_file_path, opts) }
       let(:opts) { {} }
 
@@ -30,223 +30,96 @@ module Rester
         it { is_expected.to eq true }
       end # #connected?
 
-      describe 'request validation' do
-        subject { request }
-        let(:request) { stub_adapter.send("#{verb}!", path, params) }
-        let(:verb) { 'get' }
-        let(:path) { '/' }
+      describe '#request!', :request! do
+        subject { stub_adapter.request!(verb, path, encoded_data) }
+        let(:encoded_data) { Utils.encode_www_data(params) }
         let(:context) { nil }
         let(:params) { {} }
 
         around { |ex| stub_adapter.with_context(context) { ex.run } }
 
-        context 'with invalid path' do
-          let(:path) { '/v1/invalid_path' }
+        context 'GET /v1/tests' do
+          let(:verb) { :get }
+          let(:path) { '/v1/tests' }
 
-          it 'should raise an error' do
-            expect { subject }.to raise_error Errors::StubError, "#{path} not found"
+          context 'without query params' do
+            it { is_expected.to eq [200,
+              '{"message":"no query params specified"}'] }
           end
-        end # with invalid path
 
-        context 'with invalid verb' do
-          let(:path) { '/v1/cards' }
-
-          it 'should raise an error' do
-            expect { subject }.to raise_error Errors::StubError, "GET #{path} not found"
+          context 'with no query params and context = "With error response"' do
+            let(:context) { 'With error response' }
+            it { is_expected.to eq [400, '{"error":"a_test_error"}'] }
           end
-        end # with invalid verb
 
-        context 'with invalid context' do
-          let(:context) { 'an invalid context' }
-          let(:path) { '/v1/cards/CTabcdef' }
-
-          it 'should raise an error' do
-            expect { subject }.to raise_error Errors::StubError,
-              "GET /v1/cards/CTabcdef with context '#{context}' not found"
+          context 'with 3 query params' do
+            let(:params) { { p1: 'one', p2: 2, p3: 3.3 } }
+            it { is_expected.to eq [200, '{"message":"one, 2, 3.3"}'] }
           end
-        end # with invalid context
 
-        context 'with invalid params' do
-          let(:verb) { 'post' }
-          let(:path) { '/v1/cards' }
-          let(:context) { 'With valid card details' }
+          context 'with 3 query params and context = "With error response to and three params"' do
+            let(:params) { { p1: 'one', p2: 2, p3: 3.3 } }
+            let(:context) { 'With error response to and three params' }
 
-          it 'should raise an error' do
-            expect { subject }.to raise_error Errors::StubError,
-              "POST /v1/cards with context 'With valid card details' params don't match stub. Expected: #{ {'card_number' => '4111111111111111', 'exp_month' => '08', 'exp_year' => '2017' } } Got: {}"
+            it { is_expected.to eq [400,
+              '{"error":"error_with_multiple_params"}'] }
           end
-        end # with invalid params
 
-        context 'without specifying context' do
-          let(:verb) { 'post' }
-          let(:path) { '/v1/cards' }
+          context 'with no params and context = "With three query params"' do
+            let(:context) { 'With three query params' }
 
-          context 'with matching params' do
-            let(:params) {
-              {
-                'card_number' => "4111111111111111",
-                'exp_month' => "08",
-                'exp_year' => "2017"
-              }
-            }
-
-            it 'should return a 201' do
-              expect(subject.first).to eq 201
-            end
-
-            it 'should return json body' do
-              expect(subject.last).to eq '{"token":"CTABCDEFG","exp_month":"08","exp_year":"2017","status":"ready"}'
-            end
-          end # matching params
-
-          context 'without matching params' do
-            it 'should raise an error' do
+            it 'should raise StubError' do
               expect { subject }.to raise_error Errors::StubError,
-              "POST /v1/cards with context '#{context}' not found"
+                "GET /v1/tests with context 'With three query params' params "\
+                "don't match stub. Expected: {\"p1\"=>\"one\", \"p2\"=>\"2\", "\
+                "\"p3\"=>\"3.3\"} Got: {}"
             end
-          end # without matching params
-        end # without specifying context
-      end # request validation
+          end
 
-      describe 'requests' do
-        subject { stub_adapter.send("#{verb}!", path, params) }
-        let(:status) { subject.first }
-        let(:body) { subject.last }
-        let(:path) { '/' }
-        let(:context) { nil }
-        let(:params) { {} }
+          context 'with undefined context' do
+            let(:context) { 'this context is not defined' }
 
-        around { |ex| stub_adapter.with_context(context) { ex.run } }
+            it 'should raise StubError' do
+              expect { subject }.to raise_error Errors::StubError,
+                "GET /v1/tests with context '#{context}' not found"
+            end
+          end
+        end # GET /v1/tests
 
-        describe '#get!' do
-          let(:verb) { 'get' }
+        context 'POST /v1/tests' do
+          let(:verb) { :post }
+          let(:path) { '/v1/tests' }
 
-          context 'with path /v1/cards/CTabcdef' do
-            let(:path) { '/v1/cards/CTabcdef' }
+          context 'without body' do
+            it { is_expected.to eq [201, '{"message":"posted without body"}'] }
+          end
 
-            context 'with card existing' do
-              let(:context) { 'With card existing' }
+          context 'with body' do
+            let(:params) { { p1: 'one', p2: 2, p3: 3.3 } }
+            it { is_expected.to eq [201, '{"message":"posted with body"}'] }
+          end
+        end # POST /v1/tests
 
-              it 'should return 200 status' do
-                expect(status).to eq 200
-              end
+        context 'GET /undefined_path' do
+          let(:verb) { :get }
+          let(:path) { '/undefined_path' }
 
-              it 'should return json body' do
-                expect(body).to eq '{"token":"CTabcdef","status":"ready"}'
-              end
-            end # with card existing
+          it 'should raise StubError' do
+            expect { subject }.to raise_error Errors::StubError,
+              '/undefined_path not found'
+          end
+        end
 
-            context 'with non-existent card' do
-              let(:context) { 'With non-existent card' }
+        context 'GET /no_verbs_defined' do
+          let(:verb) { :get }
+          let(:path) { '/no_verbs_defined' }
 
-              it 'should return 400 status' do
-                expect(status).to eq 400
-              end
-
-              it 'should return json body' do
-                expect(body).to eq '{"error":"validation_error","message":"card not found"}'
-              end
-            end # with non-existent card
-
-            context 'with invalid params' do
-              let(:params) {{ 'bad_field' => 'bad_field' }}
-              let(:context) { 'With card existing' }
-
-              it 'should raise an error' do
-                expect { subject }.to raise_error Errors::StubError,
-                  "GET /v1/cards/CTabcdef with context 'With card existing' params don't match stub. Expected: {} Got: {\"bad_field\"=>\"bad_field\"}"
-              end
-            end # with invalid params
-          end # with path /v1/cards/CTabcdef
-        end # #get!
-
-        describe '#delete!' do
-          let(:verb) { 'delete' }
-
-          context 'with path /v1/cards/CTabcdef' do
-            let(:path) { '/v1/cards/CTabcdef' }
-
-            context 'with card existing' do
-              let(:context) { 'With card existing' }
-
-              it 'should return 200 status' do
-                expect(status).to eq 200
-              end
-
-              it 'should return json body' do
-                expect(body).to eq '{"token":"CTabcdef","status":"deleted"}'
-              end
-            end # with card existing
-          end # with path /v1/cards/CTabcdef
-        end # #delete!
-
-        describe '#post!' do
-          let(:verb) { 'post' }
-
-          context 'with path /v1/cards' do
-            let(:path) { '/v1/cards' }
-
-            context 'with valid card details' do
-              let(:context) { 'With valid card details' }
-              let(:params) { {
-                'card_number' => "4111111111111111",
-                'exp_month' => "08",
-                'exp_year' => "2017"
-              }}
-
-              it 'should return 201 status' do
-                expect(status).to eq 201
-              end
-
-              it 'should return json body' do
-                expect(body).to eq '{"token":"CTABCDEFG","exp_month":"08","exp_year":"2017","status":"ready"}'
-              end
-            end # with valid card details
-
-            context 'with expired card' do
-              let(:context) { 'With expired card' }
-              let(:params) { {
-                'card_number' => "411111111",
-                'exp_month' => "01",
-                'exp_year' => "2000"
-              }}
-
-              it 'should return 400 status' do
-                expect(status).to eq 400
-              end
-
-              it 'should return json body' do
-                expect(body).to eq '{"error":"validation_error","message":"card expired"}'
-              end
-            end # with expired card
-          end # with path /v1/cards
-        end # #post!
-
-        describe '#put!' do
-          let(:verb) { 'put' }
-
-          context 'with path /v1/cards/CTabcdef/customers/CUabc123' do
-            let(:path) { '/v1/cards/CTabcdef/customers/CUabc123' }
-
-            context 'with valid customer' do
-              let(:context) { 'Valid customer' }
-              let(:params) { {
-                'name' => "John Smith",
-                'city' => "San Francisco",
-                'state' => "CA"
-              }}
-
-              it 'should return 200 status' do
-                expect(status).to eq 200
-              end
-
-              it 'should return json body' do
-                expect(body).to eq '{"name":"John Smith","city":"San Francisco","state":"CA","status":"valid_customer"}'
-              end
-            end # with valid customer
-          end # with path /v1/cards/CTabcdef/customers
-        end # #put!
-      end # requests
+          it 'should raise StubError' do
+            expect { subject }.to raise_error Errors::StubError,
+              'GET /no_verbs_defined not found'
+          end
+        end
+      end # #request!
     end # StubAdapter
   end # Client::Adapters
 end # Rester

--- a/spec/rester/client/adapters/stub_adapter_spec.rb
+++ b/spec/rester/client/adapters/stub_adapter_spec.rb
@@ -57,9 +57,9 @@ module Rester
             it { is_expected.to eq [200, '{"message":"one, 2, 3.3"}'] }
           end
 
-          context 'with 3 query params and context = "With error response to and three params"' do
+          context 'with 3 query params and context = "With error response and three params"' do
             let(:params) { { p1: 'one', p2: 2, p3: 3.3 } }
-            let(:context) { 'With error response to and three params' }
+            let(:context) { 'With error response and three params' }
 
             it { is_expected.to eq [400,
               '{"error":"error_with_multiple_params"}'] }

--- a/spec/rester/client/adapters/stub_adapter_spec.rb
+++ b/spec/rester/client/adapters/stub_adapter_spec.rb
@@ -65,6 +65,28 @@ module Rester
               '{"error":"error_with_multiple_params"}'] }
           end
 
+          context 'with array param and context specified' do
+            let(:context) { 'With array param' }
+            let(:params) { { array: ['one', 'two', 'three'] } }
+            it { is_expected.to eq [200, '{"message":"array_received"}'] }
+          end
+
+          context 'with hash param and context specified' do
+            let(:context) { 'With hash param' }
+            let(:params) { { hash: { p1: 'one', p2: 2, p3: 3.3 } } }
+            it { is_expected.to eq [200, '{"message":"hash_received"}'] }
+          end
+
+          context 'with array param and without context specified' do
+            let(:params) { { array: ['one', 'two', 'three'] } }
+            it { is_expected.to eq [200, '{"message":"array_received"}'] }
+          end
+
+          context 'with hash param and without context specified' do
+            let(:params) { { hash: { p1: 'one', p2: 2, p3: 3.3 } } }
+            it { is_expected.to eq [200, '{"message":"hash_received"}'] }
+          end
+
           context 'with undefined context' do
             let(:context) { 'this context is not defined' }
 

--- a/spec/rester/service/resource/params_spec.rb
+++ b/spec/rester/service/resource/params_spec.rb
@@ -153,6 +153,21 @@ module Rester
         let(:field) { :an_array }
         subject { resource_params.validate(field => value) }
 
+        context 'with nil array' do
+          let(:value) { nil }
+          it { is_expected.to eq(field => value) }
+        end
+
+        context 'with nil array and required' do
+          let(:opts) { { required: true } }
+          let(:value) { nil }
+
+          it 'should throw validation error' do
+            expect { subject }.to throw_symbol :error,
+              Errors::ValidationError.new('an_array cannot be null')
+          end
+        end
+
         context 'with array of strings' do
           let(:value) { ['1', 'two', '3.3'] }
           it { is_expected.to eq(field.to_sym => value) }
@@ -178,7 +193,7 @@ module Rester
 
         context 'with array containing "null" and required' do
           let(:opts) { { required: true } }
-          let(:value) { ['one', 'null', 'three'] }
+          let(:value) { ['one', nil, 'three'] }
 
           it 'should throw validation error' do
             expect { subject }.to throw_symbol :error,
@@ -227,12 +242,7 @@ module Rester
 
         context 'with nil value' do
           let(:value) { nil }
-
-          it 'should throw validation error' do
-            expect { subject }.to throw_symbol :error,
-              Errors::ValidationError.new(
-                "unexpected value type for #{field}: NilClass")
-          end
+          it { is_expected.to eq(field => nil) }
         end
 
         context 'with empty hash' do

--- a/spec/rester/service/resource/params_spec.rb
+++ b/spec/rester/service/resource/params_spec.rb
@@ -146,6 +146,158 @@ module Rester
         end
       end # #Float
 
+      describe '#Array', :Array do
+        let(:opts) { {} }
+        let(:block) { nil }
+        before { resource_params.Array(field, opts, &block) }
+        let(:field) { :an_array }
+        subject { resource_params.validate(field => value) }
+
+        context 'with array of strings' do
+          let(:value) { ['1', 'two', '3.3'] }
+          it { is_expected.to eq(field.to_sym => value) }
+        end
+
+        context 'with array of strings and type = Integer' do
+          let(:opts) { { type: Integer } }
+          let(:value) { ['1', '2', '3'] }
+          it { is_expected.to eq(field.to_sym => [1,2,3]) }
+        end
+
+        context 'with array of strings and type = Float' do
+          let(:opts) { { type: Float } }
+          let(:value) { ['1', '2.0', '3.3'] }
+          it { is_expected.to eq(field.to_sym => [1.0,2.0,3.3]) }
+        end
+
+        context 'with array of strings and required' do
+          let(:opts) { { required: true } }
+          let(:value) { ['one', 'two', 'three'] }
+          it { is_expected.to eq(field.to_sym => ['one', 'two', 'three']) }
+        end
+
+        context 'with array containing "null" and required' do
+          let(:opts) { { required: true } }
+          let(:value) { ['one', 'null', 'three'] }
+
+          it 'should throw validation error' do
+            expect { subject }.to throw_symbol :error,
+              Errors::ValidationError.new(
+                "#{field} cannot contain null elements"
+              )
+          end
+        end
+
+        context 'with type = Hash' do
+          let(:opts) { { type: Hash } }
+          let(:value) { [{a: 'a', b: 'b'}] }
+
+          it 'should be strict like parent' do
+            expect { subject }.to throw_symbol :error,
+              Errors::ValidationError.new('unexpected params: a, b')
+          end
+        end
+
+        context 'with type = Hash, unstrict child' do
+          let(:opts) { { type: Hash, strict: false } }
+          let(:value) { [{a: 'a'}, {b: 'b'}, {c: 'c'}] }
+
+          it 'should allow arbitrary hash keys' do
+            is_expected.to eq(field.to_sym => value)
+          end
+        end
+
+        context 'with type = Hash and block' do
+          let(:opts) { { type: Hash } }
+          let(:block) { proc { String :a; Integer :b; Float :c } }
+          let(:value) { [{a: 'a'}, {b: '2'}, {c: '3.3'}] }
+
+          it 'should parse hash values' do
+            is_expected.to eq(field.to_sym => [{a: 'a'}, {b: 2}, {c: 3.3}])
+          end
+        end
+      end # #Array
+
+      describe '#Hash' do
+        let(:opts) { {} }
+        let(:block) { nil }
+        before { resource_params.Hash(field, opts, &block) }
+        let(:field) { :a_hash }
+        subject { resource_params.validate(field => value) }
+
+        context 'with nil value' do
+          let(:value) { nil }
+
+          it 'should throw validation error' do
+            expect { subject }.to throw_symbol :error,
+              Errors::ValidationError.new(
+                "unexpected value type for #{field}: NilClass")
+          end
+        end
+
+        context 'with empty hash' do
+          let(:value) { {} }
+          it { is_expected.to eq(field.to_sym => value) }
+        end
+
+        context 'with strict parent' do
+          let(:value) { { a: 'a', b: 'b', c: 'c' } }
+
+          it 'should should be strict too' do
+            expect { subject }.to throw_symbol :error,
+              Errors::ValidationError.new('unexpected params: a, b, c')
+          end
+        end
+
+        context 'with strict parent and unstrict child' do
+          let(:opts) { { strict: false } }
+          let(:value) { { a: 'a', b: 'b', c: 'c' } }
+
+          it 'should not be strict' do
+            is_expected.to eq(field.to_sym => value)
+          end
+        end
+
+        context 'with unstrict parent' do
+          let(:params_opts) { { strict: false } }
+          let(:value) { { a: 'a', b: 'b', c: 'c' } }
+
+          it 'should inherit lack of strictness' do
+            is_expected.to eq(field.to_sym => value)
+          end
+        end
+
+        context 'with unstrict parent but strict child' do
+          let(:params_opts) { { strict: false } }
+          let(:opts) { { strict: true } }
+          let(:value) { { a: 'a', b: 'b', c: 'c' } }
+
+          it 'should should be strict' do
+            expect { subject }.to throw_symbol :error,
+              Errors::ValidationError.new('unexpected params: a, b, c')
+          end
+        end
+
+        context 'with block' do
+          let(:block) { proc { String :a; Integer :b; Float :c } }
+          let(:value) { { a: 'a', b: '2', c: '3.3' } }
+
+          it 'should parse child params' do
+            is_expected.to eq(a_hash: {a: 'a', b: 2, c: 3.3})
+          end
+        end
+
+        context 'with block and extra params given' do
+          let(:block) { proc { String :a } }
+          let(:value) { { a: 'a', b: '2', c: '3.3' } }
+
+          it 'should should complain about extra field' do
+            expect { subject }.to throw_symbol :error,
+              Errors::ValidationError.new('unexpected params: b, c')
+          end
+        end
+      end # #Hash
+
       describe '#Boolean' do
         before { resource_params.Boolean(field, opts) }
         let(:field) { :a_boolean }

--- a/spec/rester/utils_spec.rb
+++ b/spec/rester/utils_spec.rb
@@ -67,16 +67,110 @@ module Rester
         it { is_expected.to eq 'a=1&b=2&c=3.3' }
       end
 
-      context 'with nested array' do
-        let(:array) { [1,2,3] }
-        let(:data) { { array: array } }
-        it { is_expected.to eq 'array[]=1&array[]=2&array[]=3' }
+      context 'with integer data' do
+        let(:data) { { a: 1 } }
+        it { is_expected.to eq 'a=1' }
       end
 
-      context 'with nested hash' do
-        let(:hash) { { a: 'a', b: 'b', c: 'c' } }
-        let(:data) { { hash: hash } }
-        it { is_expected.to eq 'hash[a]=a&hash[b]=b&hash[c]=c' }
+      context 'with integer data' do
+        let(:data) { { a: 1, b: 2, c: 3 } }
+        it { is_expected.to eq 'a=1&b=2&c=3' }
+      end
+
+      context 'with string data' do
+        let(:data) { { a: 'aaa' } }
+        it { is_expected.to eq 'a=aaa' }
+      end
+
+      context 'with string data' do
+        let(:data) { { a: 'aaa', b: 'bbb', c: 'ccc' } }
+        it { is_expected.to eq 'a=aaa&b=bbb&c=ccc' }
+      end
+
+      context 'with float data' do
+        let(:data) { { a: 1.1 } }
+        it { is_expected.to eq 'a=1.1' }
+      end
+
+      context 'with float data' do
+        let(:data) { { a: 1.1, b: 2.22, c: 3.333 } }
+        it { is_expected.to eq 'a=1.1&b=2.22&c=3.333' }
+      end
+
+      context 'with symbol data' do
+        let(:data) { { a: :one } }
+        it { is_expected.to eq 'a=one' }
+      end
+
+      context 'with symbol data' do
+        let(:data) { { a: :one, b: :two, c: :three } }
+        it { is_expected.to eq 'a=one&b=two&c=three' }
+      end
+
+      context 'with nil data' do
+        let(:data) { { a: nil } }
+        it { is_expected.to eq 'a' }
+      end
+
+      context 'with nil data' do
+        let(:data) { { a: nil, b: nil, c: nil } }
+        it { is_expected.to eq 'a&b&c' }
+      end
+
+      context 'with empty array data' do
+        let(:data) { { a: [] } }
+        it { is_expected.to eq '' }
+      end
+
+      context 'with non-empty array data' do
+        let(:data) { { a: ['one', 2, 3.3] } }
+        it { is_expected.to eq 'a[]=one&a[]=2&a[]=3.3' }
+      end
+
+      context 'with non-empty array param containing a nil' do
+        let(:data) { { a: ['one', nil, 3.3] } }
+        it { is_expected.to eq 'a[]=one&a[]&a[]=3.3' }
+      end
+
+      context 'with two non-empty array data' do
+        let(:data) { { a: ['one', 2, 3.3], b: [1, 2.2] } }
+        it { is_expected.to eq 'a[]=one&a[]=2&a[]=3.3&b[]=1&b[]=2.2' }
+      end
+
+      context 'with nested empty array data' do
+        let(:data) { { a: [[]] } }
+        it { is_expected.to eq '' }
+      end
+
+      context 'with nested non-empty array data' do
+        let(:data) { { a: [[1], [1,2], [1,2,3]] } }
+        it { is_expected.to eq 'a[][]=1&a[][]=1&a[][]=2&a[][]=1&a[][]=2&'\
+          'a[][]=3' }
+      end
+
+      context 'with array with nested hashes data' do
+        let(:data) do
+          { a: [{one: 1}, {one: 1, two: 2}, {one: 1, two: 2, three: 3}] }
+        end
+
+        it { is_expected.to eq 'a[][one]=1&a[][one]=1&a[][two]=2&a[][one]=1&'\
+          'a[][two]=2&a[][three]=3' }
+      end
+
+      context 'with empty hash data' do
+        let(:data) { { a: {} } }
+        it { is_expected.to eq '' }
+      end
+
+      context 'with non-empty hash data' do
+        let(:data) { { a: { a: 1, b: 2.2, c: 'three', ary: [1,2]} } }
+        it { is_expected.to eq 'a[a]=1&a[b]=2.2&a[c]=three&a[ary][]=1&'\
+          'a[ary][]=2' }
+      end
+
+      context 'with nested hash data' do
+        let(:data) { { a: { hash: { one: 1, two: 2 } } } }
+        it { is_expected.to eq 'a[hash][one]=1&a[hash][two]=2' }
       end
     end # ::encode_www_data
   end # Utils

--- a/spec/rester/utils_spec.rb
+++ b/spec/rester/utils_spec.rb
@@ -67,7 +67,7 @@ module Rester
         it { is_expected.to eq 'a=1&b=2&c=3.3' }
       end
 
-      context 'with integer data' do
+      context 'with integer datum' do
         let(:data) { { a: 1 } }
         it { is_expected.to eq 'a=1' }
       end
@@ -77,7 +77,7 @@ module Rester
         it { is_expected.to eq 'a=1&b=2&c=3' }
       end
 
-      context 'with string data' do
+      context 'with string datum' do
         let(:data) { { a: 'aaa' } }
         it { is_expected.to eq 'a=aaa' }
       end
@@ -87,7 +87,7 @@ module Rester
         it { is_expected.to eq 'a=aaa&b=bbb&c=ccc' }
       end
 
-      context 'with float data' do
+      context 'with float datum' do
         let(:data) { { a: 1.1 } }
         it { is_expected.to eq 'a=1.1' }
       end
@@ -97,7 +97,7 @@ module Rester
         it { is_expected.to eq 'a=1.1&b=2.22&c=3.333' }
       end
 
-      context 'with symbol data' do
+      context 'with symbol datum' do
         let(:data) { { a: :one } }
         it { is_expected.to eq 'a=one' }
       end
@@ -107,7 +107,7 @@ module Rester
         it { is_expected.to eq 'a=one&b=two&c=three' }
       end
 
-      context 'with nil data' do
+      context 'with nil datum' do
         let(:data) { { a: nil } }
         it { is_expected.to eq 'a' }
       end

--- a/spec/rester/utils_spec.rb
+++ b/spec/rester/utils_spec.rb
@@ -48,5 +48,36 @@ module Rester
         it { is_expected.to eq(key: { integer: '1234' }) }
       end # with nested hash value
     end # ::stringify_vals
+
+    describe '::encode_www_data' do
+      subject { Utils.encode_www_data(data) }
+
+      context 'with empty hash' do
+        let(:data) { {} }
+        it { is_expected.to eq '' }
+      end
+
+      context 'with nil data' do
+        let(:data) { nil }
+        it { is_expected.to be nil }
+      end
+
+      context 'with flat data' do
+        let(:data) { { a: '1', b: 2, c: 3.3 } }
+        it { is_expected.to eq 'a=1&b=2&c=3.3' }
+      end
+
+      context 'with nested array' do
+        let(:array) { [1,2,3] }
+        let(:data) { { array: array } }
+        it { is_expected.to eq 'array[]=1&array[]=2&array[]=3' }
+      end
+
+      context 'with nested hash' do
+        let(:hash) { { a: 'a', b: 'b', c: 'c' } }
+        let(:data) { { hash: hash } }
+        it { is_expected.to eq 'hash[a]=a&hash[b]=b&hash[c]=c' }
+      end
+    end # ::encode_www_data
   end # Utils
 end # Rester

--- a/spec/rester/utils_spec.rb
+++ b/spec/rester/utils_spec.rb
@@ -1,53 +1,43 @@
 module Rester
   RSpec.describe Utils do
-    describe '::stringify_vals' do
-      subject { Utils.stringify_vals(hash) }
+    describe '::stringify' do
+      subject { Utils.stringify(hash) }
 
       context 'with empty hash' do
         let(:hash) { {} }
         it { is_expected.to eq({}) }
       end # with empty hash
 
-      context 'with mock value' do
-        let(:value) { double('double') }
-        let(:hash) { { key: value } }
-
-        it 'should receive #to_s' do
-          expect(value).to receive(:to_s).with(no_args).once
-          subject
-        end
-      end # with mock value
-
       context 'with string value' do
         let(:hash) { { key: 'value' } }
-        it { is_expected.to eq hash }
+        it { is_expected.to eq('key' => 'value') }
       end # with string value
 
       context 'with symbol value' do
         let(:hash) { { key: :value } }
-        it { is_expected.to eq(key: 'value') }
+        it { is_expected.to eq('key' => 'value') }
       end # with symbol value
 
       context 'with float value' do
         let(:hash) { { key: 3.14159 } }
-        it { is_expected.to eq(key: '3.14159') }
+        it { is_expected.to eq('key' => '3.14159') }
       end # with float value
 
       context 'with integer value' do
         let(:hash) { { key: 1234 } }
-        it { is_expected.to eq(key: '1234') }
+        it { is_expected.to eq('key' => '1234') }
       end # with integer value
 
       context 'with nil value' do
         let(:hash) { { key: nil } }
-        it { is_expected.to eq(key: 'null') }
+        it { is_expected.to eq('key' => nil) }
       end # with nil value
 
       context 'with nested hash value' do
         let(:hash) { { key: { integer: 1234 } } }
-        it { is_expected.to eq(key: { integer: '1234' }) }
+        it { is_expected.to eq('key' => { 'integer' => '1234' }) }
       end # with nested hash value
-    end # ::stringify_vals
+    end # ::stringify
 
     describe '::encode_www_data' do
       subject { Utils.encode_www_data(data) }

--- a/spec/stubs/stub_adapter_test_stub.yml
+++ b/spec/stubs/stub_adapter_test_stub.yml
@@ -1,0 +1,37 @@
+# To be used in the stub_adapter_spec
+
+/v1/tests:
+  GET:
+    Without any request params:
+      response:
+        message: no query params specified
+    With error response:
+      response[successful=false]:
+        error: a_test_error
+    With three query params:
+      request:
+        p1: one
+        p2: 2
+        p3: 3.3
+      response:
+        message: one, 2, 3.3
+    With error response to and three params:
+      request:
+        p1: one
+        p2: 2
+        p3: 3.3
+      response[successful=false]:
+        error: error_with_multiple_params
+  POST:
+    With no body:
+      response:
+        message: posted without body
+    With body:
+      request:
+        p1: one
+        p2: 2
+        p3: 3.3
+      response:
+        message: posted with body
+
+/no_verbs_defined: {}

--- a/spec/stubs/stub_adapter_test_stub.yml
+++ b/spec/stubs/stub_adapter_test_stub.yml
@@ -9,28 +9,32 @@
       response[successful=false]:
         error: a_test_error
     With three query params:
-      request:
+      request: &three_params
         p1: one
         p2: 2
         p3: 3.3
       response:
         message: one, 2, 3.3
     With error response and three params:
-      request:
-        p1: one
-        p2: 2
-        p3: 3.3
+      request: *three_params
       response[successful=false]:
         error: error_with_multiple_params
+    With array param:
+      request:
+        array: [one, two, three]
+      response:
+        message: array_received
+    With hash param:
+      request:
+        hash: *three_params
+      response:
+        message: hash_received
   POST:
     With no body:
       response:
         message: posted without body
     With body:
-      request:
-        p1: one
-        p2: 2
-        p3: 3.3
+      request: *three_params
       response:
         message: posted with body
 

--- a/spec/stubs/stub_adapter_test_stub.yml
+++ b/spec/stubs/stub_adapter_test_stub.yml
@@ -15,7 +15,7 @@
         p3: 3.3
       response:
         message: one, 2, 3.3
-    With error response to and three params:
+    With error response and three params:
       request:
         p1: one
         p2: 2

--- a/spec/support/local_adapter_test_service.rb
+++ b/spec/support/local_adapter_test_service.rb
@@ -30,6 +30,17 @@ class LocalAdapterTestService < Rester::Service
       def get(params)
         params
       end
+
+      params do
+        String :test_id
+        Array :a
+        Hash :h do
+          String :key
+        end
+      end
+      def update(params)
+        params
+      end
     end
   end
 end

--- a/spec/support/local_adapter_test_service.rb
+++ b/spec/support/local_adapter_test_service.rb
@@ -1,0 +1,35 @@
+# Intended to be used by the local_adapter_spec
+
+require 'rester'
+
+class LocalAdapterTestService < Rester::Service
+  module V1
+    class Test < Rester::Service::Resource
+      params do
+        String :query
+      end
+      def search(params)
+        if params[:query]
+          message = "query provided: #{params[:query]}"
+        else
+          message = "no query provided"
+        end
+
+        { message: message }
+      end
+
+      params do
+        String :d1
+        Integer :d2
+        Float :d3
+      end
+      def create(params)
+        params
+      end
+
+      def get(params)
+        params
+      end
+    end
+  end
+end


### PR DESCRIPTION
See issue #11.

```ruby
params do
  Array :array, type: Float, within: (0..1)

  Hash :hash, strict: false do
    # Another params block!
  end
end
```

There is an interface breaking change here, so we may want to put this in `0.5.0`.  `nil` is no longer encoded as a string "null", it's now encoded as a param without a value (e.g., `a=value&b&c=value`, here b would be `nil`).

This will cause a problem for any client that needs to be able to send `nil` up to a service.