### PR TITLE
[#104] Logging client timeouts with correlation ID.

### DIFF
--- a/lib/rester/client.rb
+++ b/lib/rester/client.rb
@@ -131,8 +131,14 @@ module Rester
 
         _set_default_headers
         start_time = Time.now.to_f
-        response = adapter.request(verb, path, params)
-        _process_response(start_time, verb, path, *response)
+
+        begin
+          response = adapter.request(verb, path, params)
+          _process_response(start_time, verb, path, *response)
+        rescue Errors::TimeoutError
+          logger.error('timed out')
+          raise
+        end
       end
     end
 


### PR DESCRIPTION
#104 